### PR TITLE
Added DataStreams based Source and streaming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 os:
   - linux
 julia:
-    - 0.5
     - 0.6
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 JavaCall 0.5.0
 Requires
 Compat 0.17

--- a/src/JDBC.jl
+++ b/src/JDBC.jl
@@ -8,11 +8,7 @@ using DBAPI
 import DBAPI: show, connect, close, isopen, commit, rollback, cursor,
               connection, execute!, rows
 
-if VERSION < v"0.4-"
-    using Dates
-else
-    using Base.Dates
-end
+using Base.Dates
 
 export DriverManager, createStatement, prepareStatement, prepareCall, executeQuery, setFetchSize,
         getInt, getFloat, getString, getShort, getByte, getTime, getTimestamp, getDate,
@@ -637,10 +633,8 @@ function Base.next(iter::JDBCRowIterator, state)
 end
 Base.done(iter::JDBCRowIterator, state) = done(iter.rs, state)
 
-if (VERSION > v"0.5-")
-    Base.iteratorsize(::JDBCRowIterator) = Base.SizeUnknown()
-    Base.iteratoreltype(::JDBCRowIterator) = Base.EltypeUnknown()
-end
+Base.iteratorsize(::JDBCRowIterator) = Base.SizeUnknown()
+Base.iteratoreltype(::JDBCRowIterator) = Base.EltypeUnknown()
 
 export getTableMetaData, JDBCRowIterator
 

--- a/src/JDBC.jl
+++ b/src/JDBC.jl
@@ -1,7 +1,6 @@
 #This file is part of JDBC.jl. License is MIT.
 module JDBC
 using JavaCall
-using Compat
 using Requires
 using DBAPI
 
@@ -167,7 +166,7 @@ executeUpdate(stmt::JStatement, query::AbstractString) = jcall(stmt, "executeUpd
 
 """
 ```
-execute(stmt::@compat(Union{JPreparedStatement, JCallableStatement}))
+execute(stmt::(Union{JPreparedStatement, JCallableStatement}))
 ```
 Executes the auery based on the Prepared Statement or Callable Statement
 
@@ -177,7 +176,7 @@ Executes the auery based on the Prepared Statement or Callable Statement
 ### Returns
 A boolean indicating whether the execution was successful or not
 """
-execute(stmt::@compat(Union{JPreparedStatement, JCallableStatement})) = jcall(stmt, "execute", jboolean, ())
+execute(stmt::Union{JPreparedStatement, JCallableStatement}) = jcall(stmt, "execute", jboolean, ())
 
 
 """
@@ -198,7 +197,7 @@ execute(stmt::JStatement, query::AbstractString) = jcall(stmt, "execute", jboole
 
 """
 ```
-executeQuery(stmt::@compat(Union{JPreparedStatement, JCallableStatement}))
+executeQuery(stmt::Union{JPreparedStatement, JCallableStatement})
 ```
 Executes the auery based on a JPreparedStatement object or a JCallableStatement object
 
@@ -208,12 +207,12 @@ Executes the auery based on a JPreparedStatement object or a JCallableStatement 
 ### Returns
 The result set as a JResultSet object
 """
-executeQuery(stmt::@compat(Union{JPreparedStatement, JCallableStatement})) = jcall(stmt, "executeQuery", JResultSet, ())
+executeQuery(stmt::Union{JPreparedStatement, JCallableStatement}) = jcall(stmt, "executeQuery", JResultSet, ())
 
 
 """
 ```
-executeUpdate(stmt::@compat(Union{JPreparedStatement, JCallableStatement}))
+executeUpdate(stmt::Union{JPreparedStatement, JCallableStatement})
 ```
 Executes the update auery based on a JPreparedStatement object or a JCallableStatement object
 
@@ -223,12 +222,12 @@ Executes the update auery based on a JPreparedStatement object or a JCallableSta
 ### Returns
 An integer indicating the status of the execution of the query
 """
-executeUpdate(stmt::@compat(Union{JPreparedStatement, JCallableStatement})) = jcall(stmt, "executeUpdate", jint, ())
+executeUpdate(stmt::Union{JPreparedStatement, JCallableStatement}) = jcall(stmt, "executeUpdate", jint, ())
 
 
 """
 ```
-clearParameters(stmt::@compat(Union{JPreparedStatement, JCallableStatement}))
+clearParameters(stmt::Union{JPreparedStatement, JCallableStatement})
 ```
 Clears the currently held parameters in a JPreparedStatement object or a JCallableStatement object
 
@@ -238,12 +237,12 @@ Clears the currently held parameters in a JPreparedStatement object or a JCallab
 ### Returns
 None
 """
-clearParameters(stmt::@compat(Union{JPreparedStatement, JCallableStatement})) = jcall(stmt, "clearParameters", Void, ())
+clearParameters(stmt::Union{JPreparedStatement, JCallableStatement}) = jcall(stmt, "clearParameters", Void, ())
 
 
 """
 ```
-setFetchSize(stmt::@compat(Union{JStatement, JPreparedStatement, JCallableStatement }), x::Integer)
+setFetchSize(stmt::Union{JStatement, JPreparedStatement, JCallableStatement }, x::Integer)
 ```
 Sets the fetch size in a JStatement or a JPreparedStatement object or a JCallableStatement object. The number of records that are returned in subsequent query executions are determined by what is set here.
 
@@ -254,7 +253,7 @@ Sets the fetch size in a JStatement or a JPreparedStatement object or a JCallabl
 ### Returns
 None
 """
-setFetchSize(stmt::@compat(Union{JStatement, JPreparedStatement, JCallableStatement }), x::Integer) = jcall(stmt, "setFetchSize", Void, (jint,), x )
+setFetchSize(stmt::Union{JStatement, JPreparedStatement, JCallableStatement }, x::Integer) = jcall(stmt, "setFetchSize", Void, (jint,), x )
 
 
 """
@@ -292,16 +291,16 @@ for s in [("String", :JString),
         m = Symbol(string("get", s[1]))
         n = Symbol(string("set", s[1]))
         v = quote
-            $m(rs::@compat(Union{JResultSet, JCallableStatement}), fld::AbstractString) = jcall(rs, $(string(m)), $(s[2]), (JString,), fld)
-            $m(rs::@compat(Union{JResultSet, JCallableStatement}), fld::Integer) = jcall(rs, $(string(m)), $(s[2]), (jint,), fld)
-            $n(stmt::@compat(Union{JPreparedStatement, JCallableStatement}), idx::Integer, v ) = jcall(stmt, $(string(n)), Void, (jint, $(s[2])), idx, v)
+            $m(rs::Union{JResultSet, JCallableStatement}, fld::AbstractString) = jcall(rs, $(string(m)), $(s[2]), (JString,), fld)
+            $m(rs::Union{JResultSet, JCallableStatement}, fld::Integer) = jcall(rs, $(string(m)), $(s[2]), (jint,), fld)
+            $n(stmt::Union{JPreparedStatement, JCallableStatement}, idx::Integer, v ) = jcall(stmt, $(string(n)), Void, (jint, $(s[2])), idx, v)
         end
         eval(v)
 end
 
 """
 ```
-getDate(rs::@compat(Union{JResultSet, JCallableStatement}), fld::AbstractString)
+getDate(rs::Union{JResultSet, JCallableStatement}, fld::AbstractString)
 ```
 Returns the Date object based on the result set or a callable statement. The value is extracted based on the column name.
 
@@ -312,12 +311,12 @@ Returns the Date object based on the result set or a callable statement. The val
 ### Returns
 The Date object.
 """
-getDate(rs::@compat(Union{JResultSet, JCallableStatement}), fld::AbstractString) = Date(convert(DateTime, jcall(rs, "getDate", @jimport(java.sql.Date), (JString,), fld)))
+getDate(rs::Union{JResultSet, JCallableStatement}, fld::AbstractString) = Date(convert(DateTime, jcall(rs, "getDate", @jimport(java.sql.Date), (JString,), fld)))
 
 
 """
 ```
-getDate(rs::@compat(Union{JResultSet, JCallableStatement}), fld::Integer)
+getDate(rs::Union{JResultSet, JCallableStatement}, fld::Integer)
 ```
 Returns the Date object based on the result set or a callable statement. The value is extracted based on the column number.
 
@@ -328,12 +327,12 @@ Returns the Date object based on the result set or a callable statement. The val
 ### Returns
 The Date object.
 """
-getDate(rs::@compat(Union{JResultSet, JCallableStatement}), fld::Integer) = Date(convert(DateTime, jcall(rs, "getDate", @jimport(java.sql.Date), (jint,), fld)))
+getDate(rs::Union{JResultSet, JCallableStatement}, fld::Integer) = Date(convert(DateTime, jcall(rs, "getDate", @jimport(java.sql.Date), (jint,), fld)))
 
 
 """
 ```
-getTimestamp(rs::@compat(Union{JResultSet, JCallableStatement}), fld::AbstractString)
+getTimestamp(rs::Union{JResultSet, JCallableStatement}, fld::AbstractString)
 ```
 Returns the Timestamp object based on the result set or a callable statement. The value is extracted based on the column name.
 
@@ -344,12 +343,12 @@ Returns the Timestamp object based on the result set or a callable statement. Th
 ### Returns
 The Timestamp object.
 """
-getTimestamp(rs::@compat(Union{JResultSet, JCallableStatement}), fld::AbstractString) = convert(DateTime, jcall(rs, "getTimestamp", @jimport(java.sql.Timestamp), (JString,), fld))
+getTimestamp(rs::Union{JResultSet, JCallableStatement}, fld::AbstractString) = convert(DateTime, jcall(rs, "getTimestamp", @jimport(java.sql.Timestamp), (JString,), fld))
 
 
 """
 ```
-getTimestamp(rs::@compat(Union{JResultSet, JCallableStatement}), fld::Integer)
+getTimestamp(rs::@Union{JResultSet, JCallableStatement}, fld::Integer)
 ```
 Returns the Timestamp object based on the result set or a callable statement. The value is extracted based on the column number.
 
@@ -360,12 +359,12 @@ Returns the Timestamp object based on the result set or a callable statement. Th
 ### Returns
 The Timestamp object.
 """
-getTimestamp(rs::@compat(Union{JResultSet, JCallableStatement}), fld::Integer) = convert(DateTime, jcall(rs, "getTimestamp", @jimport(java.sql.Timestamp), (jint,), fld))
+getTimestamp(rs::Union{JResultSet, JCallableStatement}, fld::Integer) = convert(DateTime, jcall(rs, "getTimestamp", @jimport(java.sql.Timestamp), (jint,), fld))
 
 
 """
 ```
-getTime(rs::@compat(Union{JResultSet, JCallableStatement}), fld::AbstractString)
+getTime(rs::Union{JResultSet, JCallableStatement}, fld::AbstractString)
 ```
 Returns the Time object based on the result set or a callable statement. The value is extracted based on the column name.
 
@@ -376,12 +375,12 @@ Returns the Time object based on the result set or a callable statement. The val
 ### Returns
 The Time object.
 """
-getTime(rs::@compat(Union{JResultSet, JCallableStatement}), fld::AbstractString) = convert(DateTime, jcall(rs, "getTime", @jimport(java.sql.Time), (JString,), fld))
+getTime(rs::Union{JResultSet, JCallableStatement}, fld::AbstractString) = convert(DateTime, jcall(rs, "getTime", @jimport(java.sql.Time), (JString,), fld))
 
 
 """
 ```
-getTime(rs::@compat(Union{JResultSet, JCallableStatement}), fld::Integer)
+getTime(rs::Union{JResultSet, JCallableStatement}, fld::Integer)
 ```
 Returns the Time object based on the result set or a callable statement. The value is extracted based on the column number.
 
@@ -392,9 +391,9 @@ Returns the Time object based on the result set or a callable statement. The val
 ### Returns
 The Time object.
 """
-getTime(rs::@compat(Union{JResultSet, JCallableStatement}), fld::Integer) = convert(DateTime, jcall(rs, "getTime", @jimport(java.sql.Time), (jint,), fld))
+getTime(rs::Union{JResultSet, JCallableStatement}, fld::Integer) = convert(DateTime, jcall(rs, "getTime", @jimport(java.sql.Time), (jint,), fld))
 
-Base.close(x::@compat(Union{JResultSet, JStatement, JPreparedStatement, JCallableStatement, JConnection})) = jcall(x, "close", Void, ())
+Base.close(x::Union{JResultSet, JStatement, JPreparedStatement, JCallableStatement, JConnection}) = jcall(x, "close", Void, ())
 
 wasNull(rs::JResultSet) = (jcall(rs, "wasNull", jboolean, ()) != 0)
 
@@ -537,7 +536,7 @@ global const JDBC_COLTYPE_VARBINARY = -3
 global const JDBC_COLTYPE_VARCHAR = 12
 
 #Map column types to their respective get methods
-global const get_method_dict = @compat Dict(
+global const get_method_dict = Dict(
         # JDBC_COLTYPE_ARRAY => 2003,
         JDBC_COLTYPE_BIGINT => getLong,
         # JDBC_COLTYPE_BINARY => -2,

--- a/src/datastreams.jl
+++ b/src/datastreams.jl
@@ -1,0 +1,83 @@
+using DataStreams
+using DataFrames
+
+const column_types = Dict(
+                          JDBC_COLTYPE_ARRAY=>Array,
+                          JDBC_COLTYPE_BIGINT=>Int64,
+                          JDBC_COLTYPE_BIT=>Bool,
+                          JDBC_COLTYPE_BOOLEAN=>Bool,
+                          JDBC_COLTYPE_CHAR=>String,
+                          JDBC_COLTYPE_DATE=>Date,
+                          JDBC_COLTYPE_DECIMAL=>Float64,
+                          JDBC_COLTYPE_DOUBLE=>Float64,
+                          JDBC_COLTYPE_FLOAT=>Float32,
+                          JDBC_COLTYPE_INTEGER=>Int32,
+                          JDBC_COLTYPE_LONGNVARCHAR=>String,
+                          JDBC_COLTYPE_LONGVARCHAR=>String,
+                          JDBC_COLTYPE_NCHAR=>String,
+                          JDBC_COLTYPE_NUMERIC=>Float64,
+                          JDBC_COLTYPE_NVARCHAR=>String,
+                          JDBC_COLTYPE_REAL=>Float64,
+                          JDBC_COLTYPE_ROWID=>Int64,
+                          JDBC_COLTYPE_SMALLINT=>Int16,
+                          JDBC_COLTYPE_TIME=>DateTime,
+                          JDBC_COLTYPE_TIMESTAMP=>DateTime,
+                          JDBC_COLTYPE_TINYINT=>Int8,
+                          JDBC_COLTYPE_VARCHAR=>String
+                         )
+
+
+struct Source
+    rs::JResultSet
+    md::JResultSetMetaData
+end
+Source(rs::JResultSet) = Source(rs, getMetaData(rs))
+Source(stmt::JStatement, query::AbstractString) = Source(executeQuery(stmt, query))
+
+# these methods directly access the underlying JResultSet and are used in Schema constructor
+function coltype(s::Source, col::Int)
+    dtype = get(column_types, getColumnType(s.md, col), Any)
+    if isNullable(s.md, col) == COLUMN_NO_NULLS
+        dtype
+    else
+        Union{dtype, Missing}
+    end
+end
+colname(s::Source, col::Int) = getColumnName(s.md, col)
+ncols(s::Source) = getColumnCount(s.md)
+
+coltypes(s::Source) = Type[coltype(s, i) for i ∈ 1:ncols(s)]
+colnames(s::Source) = String[colname(s, i) for i ∈ 1:ncols(s)]
+
+# WARNING: this does not seem to actually work
+Data.reset!(s::Source) = beforeFirst!(s.rs)
+
+Data.isdone(s::Source, row::Int, col::Int)  = isdone(s.rs)
+
+Data.schema(s::Source) = Data.Schema(coltypes(s), colnames(s), missing)
+
+Data.accesspattern(s::Source) = Data.Sequential
+
+Data.streamtype(::Type{Source}, ::Type{Data.Field}) = true
+Data.streamtype(::Type{Source}, ::Type{Data.Column}) = false
+
+# TODO currently jdbc_get_method is very inefficient
+pullfield(s::Source, col::Int) = jdbc_get_method(getColumnType(s.md, col))(s.rs, col)
+
+# does not store current row number as a persistent state
+function Data.streamfrom(s::Source, ::Type{Data.Field}, ::Type{T}, row::Int, col::Int) where T
+    convert(T, pullfield(s, col))::T
+end
+function Data.streamfrom(s::Source, ::Type{Data.Field}, ::Type{Union{T, Missing}},
+                         row::Int, col::Int) where T
+    o = pullfield(s, col)
+    if wasNull(s.rs)
+        return missing
+    end
+    convert(T, o)::T
+end
+
+DataFrames.readtable(s::Source) = Data.close!(Data.stream!(s, DataFrame))
+DataFrames.readtable(rs::JResultSet) = readtable(Source(rs))
+DataFrames.readtable(stmt::JStatement, query::AbstractString) = readtable(Source(stmt, query))
+

--- a/src/datastreams.jl
+++ b/src/datastreams.jl
@@ -33,6 +33,7 @@ struct Source
 end
 Source(rs::JResultSet) = Source(rs, getMetaData(rs))
 Source(stmt::JStatement, query::AbstractString) = Source(executeQuery(stmt, query))
+Source(rowit::JDBCRowIterator) = Source(rowit.rs)
 function Source(csr::JDBCCursor)
     if isnull(csr.rs)
         throw(ArgumentError("A cursor must contain a valid JResultSet to construct a Source."))
@@ -87,5 +88,5 @@ end
 DataFrames.readtable(s::Source) = Data.close!(Data.stream!(s, DataFrame))
 DataFrames.readtable(rs::JResultSet) = readtable(Source(rs))
 DataFrames.readtable(stmt::JStatement, query::AbstractString) = readtable(Source(stmt, query))
-DataFrames.readtable(csr::JDBCCursor) = readtable(Source(csr))
+DataFrames.readtable(csr::Union{JDBCCursor,JDBCRowIterator}) = readtable(Source(csr))
 

--- a/src/datastreams.jl
+++ b/src/datastreams.jl
@@ -33,6 +33,13 @@ struct Source
 end
 Source(rs::JResultSet) = Source(rs, getMetaData(rs))
 Source(stmt::JStatement, query::AbstractString) = Source(executeQuery(stmt, query))
+function Source(csr::JDBCCursor)
+    if isnull(csr.rs)
+        throw(ArgumentError("A cursor must contain a valid JResultSet to construct a Source."))
+    else
+        Source(get(csr.rs))
+    end
+end
 
 # these methods directly access the underlying JResultSet and are used in Schema constructor
 function coltype(s::Source, col::Int)
@@ -80,4 +87,5 @@ end
 DataFrames.readtable(s::Source) = Data.close!(Data.stream!(s, DataFrame))
 DataFrames.readtable(rs::JResultSet) = readtable(Source(rs))
 DataFrames.readtable(stmt::JStatement, query::AbstractString) = readtable(Source(stmt, query))
+DataFrames.readtable(csr::JDBCCursor) = readtable(Source(csr))
 

--- a/src/dbapi.jl
+++ b/src/dbapi.jl
@@ -1,4 +1,3 @@
-using DBAPI
 using JavaCall
 
 @compat abstract type JDBCInterface<:DatabaseInterface; end
@@ -34,9 +33,6 @@ function JDBCCursor(conn)
 end
 
 export JDBCInterface, JDBCError, JDBCConnection, JDBCCursor
-
-import DBAPI: show, connect, close, isopen, commit, rollback, cursor,
-              connection, execute!, rows
 
 """
 Open a JDBC Connection to the specified `host`.  The username and password can be optionally passed

--- a/src/dbapi.jl
+++ b/src/dbapi.jl
@@ -1,6 +1,6 @@
 using JavaCall
 
-@compat abstract type JDBCInterface<:DatabaseInterface; end
+abstract type JDBCInterface<:DatabaseInterface; end
 
 type JDBCConnection <: DatabaseConnection{JDBCInterface}
     conn::Nullable{JConnection}


### PR DESCRIPTION
This adds a DataStreams based source object and methods needed for streaming.  Also fixes #28 and some import conflict warnings with DBAPI.

Please note that although I tested this I was not actually able to run `runtests.jl`, as it always throws various Derby errors (seemingly unrelated to changes in this PR).