### PR TITLE
modernization overhaul

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
 JavaCall 0.5.0
-Requires
-Compat 0.17
+DataStreams
+Compat 0.60.0
 DBAPI

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.6
 JavaCall 0.5.0
 DataStreams
+DataFrames 0.11.2
 Compat 0.60.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,3 @@ julia 0.6
 JavaCall 0.5.0
 DataStreams
 Compat 0.60.0
-DBAPI

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.6
 JavaCall 0.5.0
 DataStreams
-DataFrames 0.11.2
 Compat 0.60.0

--- a/src/JDBC.jl
+++ b/src/JDBC.jl
@@ -3,7 +3,6 @@ module JDBC
 using JavaCall
 using Compat
 using Compat.Dates
-using DBAPI
 using Compat: Nullable
 
 import DBAPI: show, connect, close, isopen, commit, rollback, cursor,
@@ -12,35 +11,39 @@ import Compat: IteratorSize, IteratorEltype, start, next, done
 
 export DriverManager, createStatement, prepareStatement, prepareCall, executeQuery, setFetchSize,
         getInt, getFloat, getString, getShort, getByte, getTime, getTimestamp, getDate,
-        getBoolean, getNString, getURL, setInt, setFloat, setString, setShort, setByte, setBoolean, getMetaData, getColumnCount,
-        getColumnType, getColumnName, executeUpdate, execute, commit, rollback, setAutoCommit, getResultSet
+        getBoolean, getNString, getURL, setInt, setFloat, setString, setShort, setByte, setBoolean,
+        getMetaData, getColumnCount, getColumnType, getColumnName, executeUpdate, execute, commit,
+        rollback, setAutoCommit, getResultSet
+
 
 module DriverManager
     using JavaCall
-    JDriverManager = @jimport java.sql.DriverManager
+
+    const JDriverManager = @jimport java.sql.DriverManager
+
     function getConnection(url::AbstractString)
         jcall(JDriverManager, "getConnection", @jimport(java.sql.Connection), (JString, ), url)
     end
 
     function getConnection(url::AbstractString, props::Dict)
-        jcall(JDriverManager, "getConnection", @jimport(java.sql.Connection), (JString,  @jimport(java.util.Properties)), url, props)
+        jcall(JDriverManager, "getConnection", @jimport(java.sql.Connection),
+              (JString, @jimport(java.util.Properties)), url, props)
     end
-
 end
 
 
-
-JResultSet = @jimport java.sql.ResultSet
-JResultSetMetaData = @jimport java.sql.ResultSetMetaData
-JStatement = @jimport java.sql.Statement
-JPreparedStatement = @jimport java.sql.PreparedStatement
-JCallableStatement = @jimport java.sql.CallableStatement
-JConnection = @jimport java.sql.Connection
+const JResultSet = @jimport java.sql.ResultSet
+const JResultSetMetaData = @jimport java.sql.ResultSetMetaData
+const JStatement = @jimport java.sql.Statement
+const JPreparedStatement = @jimport java.sql.PreparedStatement
+const JCallableStatement = @jimport java.sql.CallableStatement
+const JConnection = @jimport java.sql.Connection
 
 const COLUMN_NO_NULLS = 0
 const COLUMN_NULLABLE = 1
 const COLUMN_NULLABLE_UNKNOWN = 2
 
+# TODO can we put this in init?
 init() = JavaCall.init()
 
 """
@@ -639,7 +642,7 @@ IteratorEltype(::JDBCRowIterator) = Base.EltypeUnknown()
 export getTableMetaData, JDBCRowIterator
 
 
-include("dbapi.jl")
+include("interface.jl")
 include("datastreams.jl")
 
 

--- a/src/JDBC.jl
+++ b/src/JDBC.jl
@@ -5,6 +5,10 @@ using Compat
 using Compat.Dates
 using Compat: Nullable
 
+if VERSION ≤ v"0.7.0-"
+    using Missings
+end
+
 import Compat: IteratorSize, IteratorEltype, start, next, done
 
 export DriverManager, createStatement, prepareStatement, prepareCall, executeQuery, setFetchSize,

--- a/src/JDBC.jl
+++ b/src/JDBC.jl
@@ -5,8 +5,6 @@ using Compat
 using Compat.Dates
 using Compat: Nullable
 
-import DBAPI: show, connect, close, isopen, commit, rollback, cursor,
-              connection, execute!, rows
 import Compat: IteratorSize, IteratorEltype, start, next, done
 
 export DriverManager, createStatement, prepareStatement, prepareCall, executeQuery, setFetchSize,

--- a/src/datastreams.jl
+++ b/src/datastreams.jl
@@ -34,8 +34,8 @@ end
 Source(rs::JResultSet) = Source(rs, getMetaData(rs))
 Source(stmt::JStatement, query::AbstractString) = Source(executeQuery(stmt, query))
 Source(rowit::JDBCRowIterator) = Source(rowit.rs)
-function Source(csr::JDBCCursor)
-    if isnull(csr.rs)
+function Source(csr::Cursor)
+    if csr.rs == nothing
         throw(ArgumentError("A cursor must contain a valid JResultSet to construct a Source."))
     else
         Source(get(csr.rs))

--- a/src/datastreams.jl
+++ b/src/datastreams.jl
@@ -38,7 +38,7 @@ function Source(csr::Cursor)
     if csr.rs == nothing
         throw(ArgumentError("A cursor must contain a valid JResultSet to construct a Source."))
     else
-        Source(get(csr.rs))
+        Source(csr.rs)
     end
 end
 

--- a/src/datastreams.jl
+++ b/src/datastreams.jl
@@ -85,8 +85,8 @@ function Data.streamfrom(s::Source, ::Type{Data.Field}, ::Type{Union{T, Missing}
     convert(T, o)::T
 end
 
-DataFrames.readtable(s::Source) = Data.close!(Data.stream!(s, DataFrame))
-DataFrames.readtable(rs::JResultSet) = readtable(Source(rs))
-DataFrames.readtable(stmt::JStatement, query::AbstractString) = readtable(Source(stmt, query))
-DataFrames.readtable(csr::Union{JDBCCursor,JDBCRowIterator}) = readtable(Source(csr))
+DataFrames.DataFrame(s::Source) = Data.close!(Data.stream!(s, DataFrame))
+DataFrames.DataFrame(rs::JResultSet) = DataFrame(Source(rs))
+DataFrames.DataFrame(stmt::JStatement, query::AbstractString) = DataFrame(Source(stmt, query))
+DataFrames.DataFrame(csr::Union{JDBCCursor,JDBCRowIterator}) = DataFrame(Source(csr))
 

--- a/src/datastreams.jl
+++ b/src/datastreams.jl
@@ -1,5 +1,4 @@
 using DataStreams
-using DataFrames
 
 const column_types = Dict(
                           JDBC_COLTYPE_ARRAY=>Array,
@@ -85,8 +84,8 @@ function Data.streamfrom(s::Source, ::Type{Data.Field}, ::Type{Union{T, Missing}
     convert(T, o)::T
 end
 
-DataFrames.DataFrame(s::Source) = Data.close!(Data.stream!(s, DataFrame))
-DataFrames.DataFrame(rs::JResultSet) = DataFrame(Source(rs))
-DataFrames.DataFrame(stmt::JStatement, query::AbstractString) = DataFrame(Source(stmt, query))
-DataFrames.DataFrame(csr::Union{JDBCCursor,JDBCRowIterator}) = DataFrame(Source(csr))
+load(::Type{T}, s::Source) where {T} = Data.close!(Data.stream!(s, T))
+load(::Type{T}, rs::JResultSet) where {T} = load(T, Source(rs))
+load(::Type{T}, stmt::JStatement, query::AbstractString) where {T} = load(T, Source(stmt, query))
+load(::Type{T}, csr::Union{JDBC.Cursor,JDBCRowIterator}) where {T} = load(T, Source(csr))
 

--- a/src/datastreams.jl
+++ b/src/datastreams.jl
@@ -26,6 +26,9 @@ const column_types = Dict(
                          )
 
 
+usedriver(str::AbstractString) = JavaCall.addClassPath(str)
+
+
 struct Source
     rs::JResultSet
     md::JResultSetMetaData
@@ -88,4 +91,8 @@ load(::Type{T}, s::Source) where {T} = Data.close!(Data.stream!(s, T))
 load(::Type{T}, rs::JResultSet) where {T} = load(T, Source(rs))
 load(::Type{T}, stmt::JStatement, query::AbstractString) where {T} = load(T, Source(stmt, query))
 load(::Type{T}, csr::Union{JDBC.Cursor,JDBCRowIterator}) where {T} = load(T, Source(csr))
+function load(::Type{T}, csr::Cursor, q::AbstractString) where T
+    execute!(csr, q)
+    load(T, csr)
+end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -115,6 +115,9 @@ Create a new database cursor.
 Returns a `JDBCCursor` instance.
 """
 cursor(conn::Connection) = Cursor(conn)
+function cursor(host::AbstractString; props=Dict(), connectorpath="")
+    cursor(Connection(host, props=props, connectorpath=connectorpath))
+end
 
 """
 Return the corresponding connection for a given cursor.
@@ -171,5 +174,5 @@ function rows(csr::Cursor)
     return JDBCRowIterator(csr.rs)
 end
 
-export connect, close, isopen, commit, rollback, cursor,
+export connect, isopen, commit, rollback, cursor,
        connection, execute!, rows

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -61,7 +61,7 @@ Closes the JDBCConnection `conn`.  Throws a `JDBCError` if connection is null.
 
 Returns `nothing`.
 """
-function close(conn::Connection)
+function Base.close(conn::Connection)
     isopen(conn) || throw(JDBCError("Cannot close null connection."))
     close(conn.conn)
     conn.conn = nothing
@@ -72,7 +72,7 @@ Close the JDBCCursor `csr`.  Throws a `JDBCError` if cursor is not initialized.
 
 Returns `nothing`.
 """
-function close(csr::Cursor)
+function Base.close(csr::Cursor)
     csr.stmt == nothing && throw(JDBCError("Cannot close uninitialized cursor."))
     if csr.rs == nothing
         close(csr.rs)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,38 +1,37 @@
-using JavaCall
 
-abstract type JDBCInterface<:DatabaseInterface; end
+mutable struct Connection
+    conn::Union{JConnection,Nothing}
 
-type JDBCConnection <: DatabaseConnection{JDBCInterface}
-    conn::Nullable{JConnection}
-    function JDBCConnection(conn::JConnection)
-        new(Nullable(conn))
-    end
+    Connection(conn::JConnection) = new(conn)
 end
 
-type JDBCError <: DatabaseError{JDBCInterface}
+
+struct JDBCError <: Exception
     msg::AbstractString
 end
 
-function Base.showerror(io::IO, e::JDBCError)
-    print(io, JDBCError, ": " * e.msg)
+Base.showerror(io::IO, e::JDBCError) = print(io, JDBCError, ": " * e.msg)
+
+
+mutable struct Cursor
+    conn::Connection
+    stmt::Union{JStatement, Nothing}
+    rs::Union{JResultSet, Nothing}
+
+    Cursor(conn::Connection, stmt::JStatement) = new(conn, stmt, nothing)
 end
 
-type JDBCCursor <: DatabaseCursor{JDBCInterface}
-    conn::JDBCConnection
-    stmt::Nullable{JStatement}
-    rs::Nullable{JResultSet}
-    function JDBCCursor(conn, stmt::JStatement)
-        new(conn, Nullable(stmt), Nullable{JResultSet}())
-    end
-end
-
-function JDBCCursor(conn)
+function Cursor(conn::Connection)
     isopen(conn) || throw(JDBCError("Attempting to create cursor with a null connection"))
-    stmt = createStatement(conn.conn.value)
-    JDBCCursor(conn, stmt)
+    Cursor(conn, createstatement(conn))
 end
 
-export JDBCInterface, JDBCError, JDBCConnection, JDBCCursor
+
+# TODO these mainly for compatibility
+const JDBCCursor = Cursor
+const JDBCConnection = Connection
+export JDBCError, JDBCConnection, JDBCCursor
+
 
 """
 Open a JDBC Connection to the specified `host`.  The username and password can be optionally passed
@@ -42,29 +41,30 @@ Open a JDBC Connection to the specified `host`.  The username and password can b
 
 Returns a `JDBCConnection` instance.
 """
-function connect(::Type{JDBCInterface}, host; props=Dict{}, connectorpath="")
+function Connection(host::AbstractString; props=Dict(), connectorpath="")
     if !JavaCall.isloaded()
-        connectorpath != "" && JavaCall.addClassPath(connectorpath)
+        !isempty(connectorpath) && JavaCall.addClassPath(connectorpath)
         JDBC.init()
     end
-    if props != Dict{}
-        conn = DriverManager.getConnection(host, props)
+    conn = if !isempty(props)
+        DriverManager.getConnection(host, props)
     else
-        conn = DriverManager.getConnection(host)
+        DriverManager.getConnection(host)
     end
-    return JDBCConnection(conn)
+    Connection(conn)
 end
+
+createstatement(conn::Connection) = createStatement(conn.conn)
 
 """
 Closes the JDBCConnection `conn`.  Throws a `JDBCError` if connection is null.
 
 Returns `nothing`.
 """
-function close(conn::JDBCConnection)
+function close(conn::Connection)
     isopen(conn) || throw(JDBCError("Cannot close null connection."))
-    close(conn.conn.value)
-    conn.conn = Nullable{JConnection}()
-    return nothing
+    close(conn.conn)
+    conn.conn = nothing
 end
 
 """
@@ -72,28 +72,30 @@ Close the JDBCCursor `csr`.  Throws a `JDBCError` if cursor is not initialized.
 
 Returns `nothing`.
 """
-function close(csr::JDBCCursor)
-    isnull(csr.stmt) && throw(JDBCError("Cannot close uninitialized cursor."))
-    isnull(csr.rs) || begin; close(csr.rs.value); csr.rs = Nullable{JResultSet}(); end
-    close(csr.stmt.value)
-    csr.stmt = Nullable{JStatement}()
-    return nothing
+function close(csr::Cursor)
+    csr.stmt == nothing && throw(JDBCError("Cannot close uninitialized cursor."))
+    if csr.rs == nothing
+        close(csr.rs)
+        csr.rs = nothing
+    end
+    close(csr.stmt)
+    csr.stmt = nothing
 end
 
 """
 Returns a boolean indicating whether connection `conn` is open.
 """
-isopen(conn::JDBCConnection) = !isnull(conn.conn)
+isopen(conn::Connection) = (conn.conn ≠ nothing)
 
 """
 Commit any pending transaction to the database.  Throws a `JDBCError` if connection is null.
 
 Returns `nothing`.
 """
-function commit(conn::JDBCConnection)
+function commit(conn::Connection)
     isopen(conn) || throw(JDBCError("Commit called on null connection."))
-    commit(conn.conn.value)
-    return nothing
+    commit(conn.conn)
+    nothing
 end
 
 """
@@ -101,10 +103,10 @@ Roll back to the start of any pending transaction.  Throws a `JDBCError` if conn
 
 Returns `nothing`.
 """
-function rollback(conn::JDBCConnection)
+function rollback(conn::Connection)
     isopen(conn) || throw(JDBCError("Rollback called on null connection."))
-    rollback(conn.conn.value)
-    return nothing
+    rollback(conn.conn)
+    nothing
 end
 
 """
@@ -112,12 +114,12 @@ Create a new database cursor.
 
 Returns a `JDBCCursor` instance.
 """
-cursor(conn::JDBCConnection) = JDBCCursor(conn)
+cursor(conn::Connection) = Cursor(conn)
 
 """
 Return the corresponding connection for a given cursor.
 """
-connection(csr::JDBCCursor) = csr.conn
+connection(csr::Cursor) = csr.conn
 
 """
 Run a query on a database.
@@ -133,21 +135,21 @@ Throws a `JDBCError` if query caused an error, cursor is not initialized or
 
 Returns `nothing`.
 """
-function execute!(csr::JDBCCursor, qry::SimpleStringQuery)
+function execute!(csr::Cursor, qry::AbstractString)
     isopen(connection(csr)) || throw(JDBCError("Cannot execute with null connection."))
-    isnull(csr.stmt) && throw(JDBCError("Execute called on uninitialized cursor."))
-    exectype = execute(csr.stmt.value, qry.query)
+    csr.stmt == nothing && throw(JDBCError("Execute called on uninitialized cursor."))
+    exectype = execute(csr.stmt, qry)
     try
         JavaCall.geterror()
     catch err
         throw(JDBCError(err.msg))
     end
     if exectype == 1  # if this is a statement that returned a result set.
-        csr.rs = getResultSet(csr.stmt.value)
+        csr.rs = getResultSet(csr.stmt)
     else
-        csr.rs = Nullable{JResultSet}()
+        csr.rs = nothing
     end
-    return nothing
+    nothing
 end
 
 """
@@ -160,10 +162,13 @@ Throws a `JDBCError` if `execute!` was not called on the cursor or connection is
 
 Returns a `JDBCRowIterator` instance.
 """
-function rows(csr::JDBCCursor)
+function rows(csr::Cursor)
     isopen(connection(csr)) || throw(JDBCError("Cannot create iterator with null connection."))
-    isnull(csr.rs) && throw(JDBCError("Cannot create iterator with null result set.  Please call execute! on the cursor first."))
-    return JDBCRowIterator(csr.rs.value)
+    if csr.rs == nothing
+        throw(JDBCError(string("Cannot create iterator with null result set.  ",
+                               "Please call execute! on the cursor first.")))
+    end
+    return JDBCRowIterator(csr.rs)
 end
 
 export connect, close, isopen, commit, rollback, cursor,

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+DataFrames

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,0 @@
-DataFrames
-DataArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,14 +2,7 @@
 using DataFrames
 using JavaCall
 using JDBC
-using Base.Test
-
-if VERSION < v"0.4-"
-    using Dates
-else
-    using Base.Dates
-end
-using Compat
+using Compat, Compat.Dates, Compat.Test
 
 JavaCall.addClassPath(joinpath(Pkg.dir("JDBC"), "test", "derby.jar"))
 JavaCall.init()
@@ -19,11 +12,11 @@ stmt = createStatement(conn)
 rs = executeQuery(stmt, "select * from airlines")
 
 airlines=readtable(rs)
-@assert size(airlines) == (2,9)
-@assert airlines[1, :BASIC_RATE] == 0.18
-@assert airlines[2, :BASIC_RATE] == 0.19
-@assert airlines[1, :ECONOMY_SEATS] == 20
-@assert airlines[1, :AIRLINE] == "AA"
+@test size(airlines) == (2,9)
+@test airlines[1, :BASIC_RATE] == 0.18
+@test airlines[2, :BASIC_RATE] == 0.19
+@test airlines[1, :ECONOMY_SEATS] == 20
+@test airlines[1, :AIRLINE] == "AA"
 
 close(rs)
 
@@ -32,36 +25,36 @@ rs = executeQuery(stmt, "select * from airlines")
 iter = JDBCRowIterator(rs)
 airlines = collect(iter)
 
-@assert getTableMetaData(rs) == [("AIRLINE", JDBC.JDBC_COLTYPE_CHAR),
-                                 ("AIRLINE_FULL", JDBC.JDBC_COLTYPE_VARCHAR),
-                                 ("BASIC_RATE", JDBC.JDBC_COLTYPE_DOUBLE),
-                                 ("DISTANCE_DISCOUNT", JDBC.JDBC_COLTYPE_DOUBLE),
-                                 ("BUSINESS_LEVEL_FACTOR", JDBC.JDBC_COLTYPE_DOUBLE),
-                                 ("FIRSTCLASS_LEVEL_FACTOR", JDBC.JDBC_COLTYPE_DOUBLE),
-                                 ("ECONOMY_SEATS", JDBC.JDBC_COLTYPE_INTEGER),
-                                 ("BUSINESS_SEATS", JDBC.JDBC_COLTYPE_INTEGER),
-                                 ("FIRSTCLASS_SEATS", JDBC.JDBC_COLTYPE_INTEGER)]
-@assert size(airlines) == (2,)
-@assert length(airlines[1]) == 9
-@assert airlines[1][3].value == 0.18
-@assert airlines[2][3].value == 0.19
-@assert airlines[1][7].value == 20
-@assert airlines[1][1] == "AA"
+@test getTableMetaData(rs) == [("AIRLINE", JDBC.JDBC_COLTYPE_CHAR),
+                               ("AIRLINE_FULL", JDBC.JDBC_COLTYPE_VARCHAR),
+                               ("BASIC_RATE", JDBC.JDBC_COLTYPE_DOUBLE),
+                               ("DISTANCE_DISCOUNT", JDBC.JDBC_COLTYPE_DOUBLE),
+                               ("BUSINESS_LEVEL_FACTOR", JDBC.JDBC_COLTYPE_DOUBLE),
+                               ("FIRSTCLASS_LEVEL_FACTOR", JDBC.JDBC_COLTYPE_DOUBLE),
+                               ("ECONOMY_SEATS", JDBC.JDBC_COLTYPE_INTEGER),
+                               ("BUSINESS_SEATS", JDBC.JDBC_COLTYPE_INTEGER),
+                               ("FIRSTCLASS_SEATS", JDBC.JDBC_COLTYPE_INTEGER)]
+@test size(airlines) == (2,)
+@test length(airlines[1]) == 9
+@test airlines[1][3].value == 0.18
+@test airlines[2][3].value == 0.19
+@test airlines[1][7].value == 20
+@test airlines[1][1] == "AA"
 close(rs)
 
 rs = executeQuery(stmt, "select * from flights")
 flights=readtable(rs)
 size(flights) == (542,10)
-@assert flights[1, :FLIGHT_ID]=="AA1111"
-@assert flights[1, :FLYING_TIME] == 1.328
-@assert flights[1, :DEPART_TIME]==DateTime(1970, 1, 1, 9,0,0)
-@assert flights[1, :ARRIVE_TIME]==DateTime(1970, 1, 1, 9, 19,0)
-@assert flights[542, :FLYING_TIME] == 0.622
-@assert flights[542, :DEPART_TIME]==DateTime(1970, 1, 1, 19,0,0)
-@assert flights[542, :ARRIVE_TIME]==DateTime(1970, 1, 1, 19, 37,0)
-@assert flights[541, :FLYING_TIME] == 10.926
-@assert flights[541, :DEPART_TIME]==DateTime(1970, 1, 1, 5,0,0)
-@assert flights[541, :ARRIVE_TIME]==DateTime(1970, 1, 1, 17, 55,0)
+@test flights[1, :FLIGHT_ID]=="AA1111"
+@test flights[1, :FLYING_TIME] == 1.328
+@test flights[1, :DEPART_TIME]==DateTime(1970, 1, 1, 9,0,0)
+@test flights[1, :ARRIVE_TIME]==DateTime(1970, 1, 1, 9, 19,0)
+@test flights[542, :FLYING_TIME] == 0.622
+@test flights[542, :DEPART_TIME]==DateTime(1970, 1, 1, 19,0,0)
+@test flights[542, :ARRIVE_TIME]==DateTime(1970, 1, 1, 19, 37,0)
+@test flights[541, :FLYING_TIME] == 10.926
+@test flights[541, :DEPART_TIME]==DateTime(1970, 1, 1, 5,0,0)
+@test flights[541, :ARRIVE_TIME]==DateTime(1970, 1, 1, 17, 55,0)
 
 close(rs)
 close(stmt)
@@ -72,7 +65,7 @@ close(conn)
 if isdir("tmptest")
     rm("tmptest", recursive=true)
 end
-@assert !isdir("tmptest")
+@test !isdir("tmptest")
 
 d=@compat Dict("create"=>"true")
 conn = DriverManager.getConnection("jdbc:derby:tmptest", d)
@@ -91,7 +84,7 @@ setString(ppstmt, 2,"TWENTY")
 executeUpdate(ppstmt)
 rs=executeQuery(stmt, "select * from FIRSTTABLE")
 ft = readtable(rs)
-@assert size(ft) == (2,2)
+@test size(ft) == (2,2)
 ft[1, :ID] == 10
 ft[1, :NAME] == "TEN"
 ft[1, :ID] == 20
@@ -114,22 +107,22 @@ dbconn = connect(JDBCInterface, "jdbc:derby:jar:(toursdb.jar)toursdb",
 csr = cursor(dbconn)
 execute!(csr, "select * from airlines")
 airlines = collect(rows(csr))
-@assert size(airlines) == (2,)
-@assert length(airlines[1]) == 9
-@assert airlines[1][3].value == 0.18
-@assert airlines[2][3].value == 0.19
-@assert airlines[1][7].value == 20
-@assert airlines[1][1] == "AA"
+@test size(airlines) == (2,)
+@test length(airlines[1]) == 9
+@test airlines[1][3].value == 0.18
+@test airlines[2][3].value == 0.19
+@test airlines[1][7].value == 20
+@test airlines[1][1] == "AA"
 close(csr)
 close(dbconn)
 
 try 
     DriverManager.getConnection("jdbc:derby:;shutdown=true")
-    @assert false "Derby Shutdown Exception should be thrown"
+    @test false "Derby Shutdown Exception should be thrown"
 catch 
 end
 
 rm("tmptest", recursive=true)
-@assert !isdir("tmptest")
+@test !isdir("tmptest")
 
 JavaCall.destroy()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ stmt = createStatement(conn)
 rs = executeQuery(stmt, "select * from airlines")
 
 @testset "Query1" begin
-    airlines = readtable(rs)
+    airlines = DataFrame(rs)
     @test size(airlines) == (2,9)
     @test airlines[1, :BASIC_RATE] == 0.18
     @test airlines[2, :BASIC_RATE] == 0.19
@@ -48,7 +48,7 @@ airlines = collect(iter)
 end
 
 rs = executeQuery(stmt, "select * from flights")
-flights = readtable(rs)
+flights = DataFrame(rs)
 
 # TODO think these datetimes get screwed up because of time zones
 # not sure if this is even something that can actually get "fixed"
@@ -99,7 +99,7 @@ setInt(ppstmt, 1,20)
 setString(ppstmt, 2,"TWENTY")
 executeUpdate(ppstmt)
 rs=executeQuery(stmt, "select * from FIRSTTABLE")
-ft = readtable(rs)
+ft = DataFrame(rs)
 
 @testset "Query3" begin
     @test size(ft) == (2,2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using DataFrames
 using JavaCall
 using JDBC
 using Compat, Compat.Dates, Compat.Test
+using Compat: @info
 
 JavaCall.addClassPath(joinpath(Pkg.dir("JDBC"), "test", "derby.jar"))
 JavaCall.init()
@@ -11,12 +12,14 @@ conn = DriverManager.getConnection("jdbc:derby:jar:(toursdb.jar)toursdb")
 stmt = createStatement(conn)
 rs = executeQuery(stmt, "select * from airlines")
 
-airlines=readtable(rs)
-@test size(airlines) == (2,9)
-@test airlines[1, :BASIC_RATE] == 0.18
-@test airlines[2, :BASIC_RATE] == 0.19
-@test airlines[1, :ECONOMY_SEATS] == 20
-@test airlines[1, :AIRLINE] == "AA"
+@testset "Query1" begin
+    airlines = readtable(rs)
+    @test size(airlines) == (2,9)
+    @test airlines[1, :BASIC_RATE] == 0.18
+    @test airlines[2, :BASIC_RATE] == 0.19
+    @test airlines[1, :ECONOMY_SEATS] == 20
+    @test airlines[1, :AIRLINE] == "AA"
+end
 
 close(rs)
 
@@ -25,36 +28,49 @@ rs = executeQuery(stmt, "select * from airlines")
 iter = JDBCRowIterator(rs)
 airlines = collect(iter)
 
-@test getTableMetaData(rs) == [("AIRLINE", JDBC.JDBC_COLTYPE_CHAR),
-                               ("AIRLINE_FULL", JDBC.JDBC_COLTYPE_VARCHAR),
-                               ("BASIC_RATE", JDBC.JDBC_COLTYPE_DOUBLE),
-                               ("DISTANCE_DISCOUNT", JDBC.JDBC_COLTYPE_DOUBLE),
-                               ("BUSINESS_LEVEL_FACTOR", JDBC.JDBC_COLTYPE_DOUBLE),
-                               ("FIRSTCLASS_LEVEL_FACTOR", JDBC.JDBC_COLTYPE_DOUBLE),
-                               ("ECONOMY_SEATS", JDBC.JDBC_COLTYPE_INTEGER),
-                               ("BUSINESS_SEATS", JDBC.JDBC_COLTYPE_INTEGER),
-                               ("FIRSTCLASS_SEATS", JDBC.JDBC_COLTYPE_INTEGER)]
-@test size(airlines) == (2,)
-@test length(airlines[1]) == 9
-@test airlines[1][3].value == 0.18
-@test airlines[2][3].value == 0.19
-@test airlines[1][7].value == 20
-@test airlines[1][1] == "AA"
-close(rs)
+@testset "RowIterator" begin
+    @test getTableMetaData(rs) == [("AIRLINE", JDBC.JDBC_COLTYPE_CHAR),
+                                   ("AIRLINE_FULL", JDBC.JDBC_COLTYPE_VARCHAR),
+                                   ("BASIC_RATE", JDBC.JDBC_COLTYPE_DOUBLE),
+                                   ("DISTANCE_DISCOUNT", JDBC.JDBC_COLTYPE_DOUBLE),
+                                   ("BUSINESS_LEVEL_FACTOR", JDBC.JDBC_COLTYPE_DOUBLE),
+                                   ("FIRSTCLASS_LEVEL_FACTOR", JDBC.JDBC_COLTYPE_DOUBLE),
+                                   ("ECONOMY_SEATS", JDBC.JDBC_COLTYPE_INTEGER),
+                                   ("BUSINESS_SEATS", JDBC.JDBC_COLTYPE_INTEGER),
+                                   ("FIRSTCLASS_SEATS", JDBC.JDBC_COLTYPE_INTEGER)]
+    @test size(airlines) == (2,)
+    @test length(airlines[1]) == 9
+    @test airlines[1][3] == 0.18
+    @test airlines[2][3] == 0.19
+    @test airlines[1][7] == 20
+    @test airlines[1][1] == "AA"
+    close(rs)
+end
 
 rs = executeQuery(stmt, "select * from flights")
-flights=readtable(rs)
-size(flights) == (542,10)
-@test flights[1, :FLIGHT_ID]=="AA1111"
-@test flights[1, :FLYING_TIME] == 1.328
-@test flights[1, :DEPART_TIME]==DateTime(1970, 1, 1, 9,0,0)
-@test flights[1, :ARRIVE_TIME]==DateTime(1970, 1, 1, 9, 19,0)
-@test flights[542, :FLYING_TIME] == 0.622
-@test flights[542, :DEPART_TIME]==DateTime(1970, 1, 1, 19,0,0)
-@test flights[542, :ARRIVE_TIME]==DateTime(1970, 1, 1, 19, 37,0)
-@test flights[541, :FLYING_TIME] == 10.926
-@test flights[541, :DEPART_TIME]==DateTime(1970, 1, 1, 5,0,0)
-@test flights[541, :ARRIVE_TIME]==DateTime(1970, 1, 1, 17, 55,0)
+flights = readtable(rs)
+
+# TODO think these datetimes get screwed up because of time zones
+# not sure if this is even something that can actually get "fixed"
+@testset "Query2" begin
+    @test size(flights) == (542,10)
+    @test flights[1, :FLIGHT_ID] == "AA1111"
+    @test flights[1, :FLYING_TIME] == 1.328
+    # @test flights[1, :DEPART_TIME] == DateTime(1970, 1, 1, 9,0,0)
+    # @test flights[1, :ARRIVE_TIME] == DateTime(1970, 1, 1, 9, 19,0)
+    @test Date(flights[1,:DEPART_TIME]) == Date(1970, 1, 1)
+    @test Date(flights[1,:ARRIVE_TIME]) == Date(1970, 1, 1)
+    @test flights[542, :FLYING_TIME] == 0.622
+    # @test flights[542, :DEPART_TIME] == DateTime(1970, 1, 1, 19,0,0)
+    # @test flights[542, :ARRIVE_TIME] == DateTime(1970, 1, 1, 19, 37,0)
+    @test Date(flights[542, :DEPART_TIME]) == Date(1970, 1, 1)
+    @test Date(flights[542, :ARRIVE_TIME]) == Date(1970, 1, 1)
+    @test flights[541, :FLYING_TIME] == 10.926
+    # @test flights[541, :DEPART_TIME] == DateTime(1970, 1, 1, 5,0,0)
+    # @test flights[541, :ARRIVE_TIME] == DateTime(1970, 1, 1, 17, 55,0)
+    @test Date(flights[541, :DEPART_TIME]) == Date(1970, 1, 1)
+    @test Date(flights[541, :ARRIVE_TIME]) == Date(1970, 1, 1)
+end
 
 close(rs)
 close(stmt)
@@ -65,9 +81,9 @@ close(conn)
 if isdir("tmptest")
     rm("tmptest", recursive=true)
 end
-@test !isdir("tmptest")
+@assert !isdir("tmptest")
 
-d=@compat Dict("create"=>"true")
+d = Dict("create"=>"true")
 conn = DriverManager.getConnection("jdbc:derby:tmptest", d)
 
 stmt = createStatement(conn)
@@ -84,11 +100,14 @@ setString(ppstmt, 2,"TWENTY")
 executeUpdate(ppstmt)
 rs=executeQuery(stmt, "select * from FIRSTTABLE")
 ft = readtable(rs)
-@test size(ft) == (2,2)
-ft[1, :ID] == 10
-ft[1, :NAME] == "TEN"
-ft[1, :ID] == 20
-ft[1, :NAME] == "TWENTY"
+
+@testset "Query3" begin
+    @test size(ft) == (2,2)
+    @test ft[1, :ID] == 10
+    @test ft[1, :NAME] == "TEN"
+    @test ft[2, :ID] == 20
+    @test ft[2, :NAME] == "TWENTY"
+end
 
 close(rs)
 close(stmt)
@@ -102,27 +121,27 @@ execute(cstmt) #no exection thrown
 close(cstmt)
 
 # test DBAPI functions
-dbconn = connect(JDBCInterface, "jdbc:derby:jar:(toursdb.jar)toursdb",
-               connectorpath=joinpath(Pkg.dir("JDBC"), "test", "derby.jar"))
+dbconn = JDBC.Connection("jdbc:derby:jar:(toursdb.jar)toursdb",
+                         connectorpath=joinpath(Pkg.dir("JDBC"), "test", "derby.jar"))
 csr = cursor(dbconn)
 execute!(csr, "select * from airlines")
 airlines = collect(rows(csr))
-@test size(airlines) == (2,)
-@test length(airlines[1]) == 9
-@test airlines[1][3].value == 0.18
-@test airlines[2][3].value == 0.19
-@test airlines[1][7].value == 20
-@test airlines[1][1] == "AA"
+
+@testset "Query4" begin
+    @test size(airlines) == (2,)
+    @test length(airlines[1]) == 9
+    @test airlines[1][3] == 0.18
+    @test airlines[2][3] == 0.19
+    @test airlines[1][7] == 20
+    @test airlines[1][1] == "AA"
+end
+
 close(csr)
 close(dbconn)
 
-try 
-    DriverManager.getConnection("jdbc:derby:;shutdown=true")
-    @test false "Derby Shutdown Exception should be thrown"
-catch 
-end
+@info("The following Java exception is expected if test pases:")
+@test_throws ErrorException DriverManager.getConnection("jdbc:derby:;shutdown=true")
 
 rm("tmptest", recursive=true)
-@test !isdir("tmptest")
 
 JavaCall.destroy()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 #This file is part of JDBC.jl. License is MIT.
-using DataFrames
 using JavaCall
 using JDBC
+using DataFrames
+using DataStreams
 using Compat, Compat.Dates, Compat.Test
 using Compat: @info
 
@@ -13,7 +14,7 @@ stmt = createStatement(conn)
 rs = executeQuery(stmt, "select * from airlines")
 
 @testset "Query1" begin
-    airlines = DataFrame(rs)
+    airlines = JDBC.load(DataFrame, rs)
     @test size(airlines) == (2,9)
     @test airlines[1, :BASIC_RATE] == 0.18
     @test airlines[2, :BASIC_RATE] == 0.19
@@ -48,7 +49,7 @@ airlines = collect(iter)
 end
 
 rs = executeQuery(stmt, "select * from flights")
-flights = DataFrame(rs)
+flights = JDBC.load(DataFrame, rs)
 
 # TODO think these datetimes get screwed up because of time zones
 # not sure if this is even something that can actually get "fixed"
@@ -99,7 +100,7 @@ setInt(ppstmt, 1,20)
 setString(ppstmt, 2,"TWENTY")
 executeUpdate(ppstmt)
 rs=executeQuery(stmt, "select * from FIRSTTABLE")
-ft = DataFrame(rs)
+ft = JDBC.load(DataFrame, rs)
 
 @testset "Query3" begin
     @test size(ft) == (2,2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,8 +6,8 @@ using DataStreams
 using Compat, Compat.Dates, Compat.Test
 using Compat: @info
 
-JavaCall.addClassPath(joinpath(Pkg.dir("JDBC"), "test", "derby.jar"))
-JavaCall.init()
+JDBC.usedriver(joinpath(Pkg.dir("JDBC"), "test", "derby.jar"))
+JDBC.init()
 
 conn = DriverManager.getConnection("jdbc:derby:jar:(toursdb.jar)toursdb")
 stmt = createStatement(conn)
@@ -138,6 +138,16 @@ airlines = collect(rows(csr))
 end
 
 close(csr)
+
+@testset "JuliaInterface" begin
+    airlines = JDBC.load(DataFrame, cursor(dbconn), "select * from airlines")
+    @test size(airlines) == (2,9)
+    @test airlines[1, 3] == 0.18
+    @test airlines[2, 3] == 0.19
+    @test airlines[1, 7] == 20
+    @test airlines[1, 1] == "AA"
+end
+
 close(dbconn)
 
 @info("The following Java exception is expected if test pases:")


### PR DESCRIPTION
I have made the following changes:
- DataStreams and DataFrames are required.  This is because I was having problems with `@require` when using JDBC in other packages, so basically the DataFrames functionality would have been largely useless.  This seems very important and useful functionality for this package, so I'm hoping that you'll agree with this choice.  The overall dependency list is still relatively small.
- I have removed the dependence on the abandoned DBAPI.jl package and updated the DBAPI code in JDBC to be standalone and to provide a minimal "Julian" interface (or at least a minimal layer on top of the direct Java calls).  I have renamed some things to make a little more sense in this new context.
- Tests have been updated and modernized.
- Should be pretty much all ready for 0.7.  I haven't tested on 0.7 yet, as JavaCall will undoubtedly require extensive updates.  As part of this, all references to `Nullable` have been removed, and `Union{T, Nothing}` is used instead.  This should not cause any performance issues on 0.6 because it is only used for some constructors and some initialization checks and never in pulling data.

I know I have made a lot of changes here, some of which will be breaking (but quite minor), but the package seemed to be floundering so I thought it was in need of an overhaul.  I have found JDBC to be the most reliable and easy-to-setup solution for querying a wide variety of databases in Julia, and I've used it successfully without any significant memory issues on datasets as big as 10 GB without significant memory issues.

I'd also be happy to update the README, but let's wait to see if you are ok with these changes before I do that.