### PR TITLE
switch from DataStreams to Tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ os:
 
 julia:
   - 1.0
-  - 1.2
+  - 1.3
   - nightly
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,28 @@
+
+sudo: required
+
 language: julia
+
+services:
+  - docker
+
 os:
+  - osx
   - linux
+
 julia:
-    - 0.7
-    - 1.0
+  - 1.0
+  - 1.2
+  - nightly
+
+matrix:
+  allow_failures:
+  - julia: nightly
+
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("JDBC"); Pkg.test("JDBC"; coverage=true)'
+
+after_success:
+  - julia -e 'import Pkg, JDBC; cd(joinpath(dirname(pathof(JDBC)),"..")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+  - julia -e 'import Pkg; Pkg.add("Documenter")'
+  - julia -e 'import JDBC; cd(joinpath(dirname(pathof(JDBC)),"..")); include(joinpath("docs", "make.jl"))'

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JDBC"
 uuid = "6042db11-3c3d-5e84-8dba-9cbf74c9ba48"
-version = "0.5.0"
+version = "0.4.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JDBC"
 uuid = "6042db11-3c3d-5e84-8dba-9cbf74c9ba48"
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -3,12 +3,11 @@ uuid = "6042db11-3c3d-5e84-8dba-9cbf74c9ba48"
 version = "0.4.1"
 
 [deps]
-DataStreams = "9a8bc11e-79be-5b39-94d7-1ccc349a1a85"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 JavaCall = "494afd89-becb-516b-aafa-70d2670c0337"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-DataFrames = "< 0.18.0"
 JavaCall = "≥ 0.7.0"
 julia = "≥ 0.7.0"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This package enables the use of Java JDBC drivers to access databases from within Julia. It uses the [JavaCall.jl](https://github.com/aviks/JavaCall.jl) package to call into Java in order to use the JDBC drivers. 
 
 The API provided by this package consists essentially of two components: a "direct" (i.e. minimally wrapped) interface directly to Java JDBC and a minimal
-Julian interface with support for [DataStreams.jl](https://github.com/JuliaData/DataStreams.jl).
+Julian interface with support for [Tables.jl](https://github.com/JuliaData/Tables.jl).
 
 This package currently supports only Julia v0.6 and later.
 
@@ -121,13 +121,13 @@ end
 close(csr)  # closes Connection, can be called on Connection or Cursor
 ```
 
-#### `DataStreams` Interface and Creating `DataFrame`s
+#### `Tables` Interface and Creating `DataFrame`s
 
-JDBC includes a [DataStreams](https://github.com/JuliaData/DataStreams.jl) interface.  A DataStreams `Source` object can be created from a `JDBC.Cursor` or a
-`JDBCRowIterator` simply by doing e.g. `JDBC.Source(csr)`.  This object implements the DataStreams `Data.Source` interface.  It can be useful for retrieving metadata
-with `Data.schema`.
+JDBC includes a [Tables](https://github.com/JuliaData/Tables.jl) interface.  A Tables
+`Source` object can be created from a `JDBC.Cursor` or a `JDBCRowIterator` simply by doing
+e.g. `JDBC.Source(csr)`.  It can be useful for retrieving metadata with `Tables.schema`.
 
-This is also useful for loading data from a database into an object that implements the DataStreams `Data.Sink` interface such as a `DataFrame`.  For this we
+This is also useful for loading data from a database into another object that implements the Tables interface.  For this we
 provide also the convenient `JDBC.load` function.
 
 For example, you can do

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7
-JavaCall 0.7.0
-DataStreams

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: 1.2
+  - julia_version: 1.3
   - julia_version: nightly
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - julia_version: 0.7
-  - julia_version: 1
+  - julia_version: 1.0
+  - julia_version: 1.2
   - julia_version: nightly
 
 platform:
@@ -12,8 +12,7 @@ platform:
 # # (tests will run but not make your overall status red)
 matrix:
   allow_failures:
-  - julia_version: nightly
-  - platform: x86
+    - julia_version: nightly
 
 branches:
   only:

--- a/src/JDBC.jl
+++ b/src/JDBC.jl
@@ -640,7 +640,7 @@ export getTableMetaData, JDBCRowIterator
 
 
 include("interface.jl")
-include("datastreams.jl")
+include("tables.jl")
 
 
 end # module

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-DataFrames

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@
 using JavaCall
 using JDBC
 using DataFrames
-using DataStreams
 using Test
 using Dates
 import Pkg


### PR DESCRIPTION
This is a duplicate of #46.  I have made several fixes so that tests now pass and updated Travis and Appveyor.  Making a new PR was just easier than me figuring out how to update the existing one.

Thanks again to @quinnj for having made this.  I think the only reason it got ignored so long was because JavaCall was not working until 1.3.